### PR TITLE
Supply kubeconfig via flag

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -18,13 +18,7 @@ type HookController struct {
 	TPR    *v1beta1.ThirdPartyResource
 }
 
-func NewHookController() HookController {
-	// creates the in-cluster config
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		panic(err.Error())
-	}
-
+func NewHookController(config rest.Config) HookController {
 	// creates the clientset
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {

--- a/controller.go
+++ b/controller.go
@@ -18,7 +18,7 @@ type HookController struct {
 	TPR    *v1beta1.ThirdPartyResource
 }
 
-func NewHookController(config rest.Config) HookController {
+func NewHookController(config *rest.Config) HookController {
 	// creates the clientset
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {

--- a/controller.go
+++ b/controller.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 )
 
-var HOOK_TPR string = "hookjob.example.com"
+var HOOK_TPR string = "hook-job.example.com"
 
 type HookController struct {
 	Client *kubernetes.Clientset

--- a/main.go
+++ b/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"html/template"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	"log"
 	"net/http"
 )
@@ -29,10 +31,23 @@ func (c Creator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	// creates the in-cluster config
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		panic(err.Error())
+	kubeconfig := flag.String("kubeconfig", "", "Location of kubeconfig (default will use serviceaccount token)")
+	flag.Parse()
+
+	var config *rest.Config
+	var err error
+	if *kubeconfig == "" {
+		// creates the in-cluster config
+		config, err = rest.InClusterConfig()
+		if err != nil {
+			panic("Unable to load in-cluster configuration; if you're running captainhook from outside a cluster don't forget to use the `-kubeconfig` option")
+		}
+    } else {
+        // use the current context in kubeconfig
+		config, err = clientcmd.BuildConfigFromFlags("", *kubeconfig)
+		if err != nil {
+			panic(err.Error())
+		}
 	}
 	
 	manager := NewHookManager()

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"html/template"
+	"k8s.io/client-go/rest"
 	"log"
 	"net/http"
 )
@@ -28,8 +29,14 @@ func (c Creator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	// creates the in-cluster config
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		panic(err.Error())
+	}
+	
 	manager := NewHookManager()
-	controller := NewHookController()
+	controller := NewHookController(config)
 	http.Handle("/", Homepage{manager})
 	http.Handle("/create/", Creator{manager})
 	http.Handle("/hookjob/", controller)


### PR DESCRIPTION
This should simplify local development because I won't need to run captainhook inside pod and rely on service account tokens to connect to a Kubernetes cluster. This may simplify testing in the long run as well.